### PR TITLE
Enable conversion of a range of date-times

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ these data with either the Weather Research and Forecasting (WRF) model or the
 Model for Prediction Across Scales - Atmosphere (MPAS-A).
 
 The only required command-line argument is the date-time, in YYYY-MM-DD_HH
-format, of ERA5 model-level files to process. With no optional arguments, the
-script will search known paths on the NWSC Glade filesystem for ERA5 model-level
-netCDF files. If the `-p`/`--path` option is provided with a local path, the
-script will instead search that local path for ERA5 files that have been
-downloaded from the NSF NCAR Research Data Archive (RDA) ds633 datasets.
+format, of ERA5 model-level files to convert. For example:
+```
+era5_to_int.py 2024-05-01_00
+```
+
+Conversion of a range of date-times is possible through the use of additional
+command-line arguments as described in the Usage section.
 
 The following fields from the ds633 datasets are handled by the script:
 
@@ -51,21 +53,52 @@ The `era5_to_int.py` script requires:
 
 ## Usage
 
-Usage is provided by running the `era5_to_int.py` script with the `-h`/`--help`
-argument, which prints the following:
+The only required command-line argument is the date-time, in YYYY-MM-DD_HH
+format, of ERA5 model-level files to convert. For example:
 ```
-  usage: era5_to_int.py [-h] [-p PATH] datetime
-
-  positional arguments:
-    datetime              the date-time to convert in YYYY-MM-DD_HH format
-
-  options:
-    -h, --help            show this help message and exit
-    -p PATH, --path PATH  the local path to search for ERA5 netCDF files
+era5_to_int.py 2024-05-01_00
 ```
 
 Upon successful completion, an intermediate file with the prefix `ERA5` is
-created in the current working directory; for example, `ERA5:2023-01-28_00`.
+created in the current working directory; for example, `ERA5:2024-05-01_00`.
+
+With no optional arguments, the script will search known paths on the NWSC Glade
+filesystem for ERA5 model-level netCDF files. If the `-p`/`--path` option is
+provided with a local path, the script will instead search that local path for
+ERA5 files that have been downloaded from the NSF NCAR Research Data Archive
+(RDA) ds633 datasets. For example:
+```
+era5_to_int.py --path /some/data/directory/era5 2024-05-01_00
+```
+
+Processing a range of times is possible by providing as a second positional
+argument the date-time until which time records should be converted. For
+example, to converted the entire month of May 2024:
+```
+era5_to_int.py 2024-05-01_00 2024-05-31_18
+```
+
+By default, fields are converted at a six-hourly interval, and a different
+interval may be specified with a third positional argument. For example, to
+convert data at a three-hourly interval for the month of May 2024:
+```
+era5_to_int.py 2024-05-01_00 2024-05-31_21 3
+```
+
+Usage is provided by running the `era5_to_int.py` script with the `-h`/`--help`
+argument, which prints the following:
+```
+usage: era5_to_int.py [-h] [-p PATH] datetime [until_datetime] [interval_hours]
+
+positional arguments:
+  datetime              the date-time to convert in YYYY-MM-DD_HH format
+  until_datetime        the date-time in YYYY-MM-DD_HH format until which records are converted (Default: datetime)
+  interval_hours        the interval in hours between records to be converted (Default: 6)
+
+options:
+  -h, --help            show this help message and exit
+  -p PATH, --path PATH  the local path to search for ERA5 netCDF files
+```
 
 ## Supplementary files
 

--- a/era5_to_int.py
+++ b/era5_to_int.py
@@ -34,6 +34,20 @@ def datetime_to_string(dt):
     return '{:04d}-{:02d}-{:02d}_{:02d}'.format(dt.year, dt.month, dt.day, dt.hour)
 
 
+def string_to_yyyymmddhh(str):
+    """ Given a string of the form yyyy-mm-dd_hh, returns the component year,
+    month, day, and hour as a tuple of integers.
+    """
+    tmp = str.split('-')
+    yyyy = int(tmp[0])
+    mm = int(tmp[1])
+    ddhh = tmp[2]
+    dd = int(ddhh.split('_')[0])
+    hh = int(ddhh.split('_')[1])
+
+    return yyyy, mm, dd, hh
+
+
 def begin_6hourly(yyyy, mm, dd, hh):
     """ Returns a date-time string of the form yyyymmddhh for the year, month,
     day, and hour with the hours rounded down the the beginning of a six-hour
@@ -127,12 +141,7 @@ def find_era5_file(var, validtime, localpaths=None):
     else:
         file_paths = glade_paths
 
-    tmp = validtime.split('-')
-    yyyy = int(tmp[0])
-    mm = int(tmp[1])
-    ddhh = tmp[2]
-    dd = int(ddhh.split('_')[0])
-    hh = int(ddhh.split('_')[1])
+    yyyy, mm, dd, hh = string_to_yyyymmddhh(validtime)
 
     begin_date = var.beginDateFn(yyyy, mm, dd, hh)
     end_date = var.endDateFn(yyyy, mm, dd, hh)
@@ -164,12 +173,7 @@ def find_time_index(ncfilename, validtime):
     from netCDF4 import Dataset
     import numpy as np
 
-    tmp = validtime.split('-')
-    yyyy = int(tmp[0])
-    mm = int(tmp[1])
-    ddhh = tmp[2]
-    dd = int(ddhh.split('_')[0])
-    hh = int(ddhh.split('_')[1])
+    yyyy, mm, dd, hh = string_to_yyyymmddhh(validtime)
 
     needed_date = yyyy * 1000000 + mm * 10000 + dd * 100 + hh
 
@@ -217,21 +221,11 @@ def handle_datetime_args(args):
     If 'interval_hours' is 0, it defaults to a interval of six hours.
     """
 
-    tmp = args.datetime.split('-')
-    yyyy = int(tmp[0])
-    mm = int(tmp[1])
-    ddhh = tmp[2]
-    dd = int(ddhh.split('_')[0])
-    hh = int(ddhh.split('_')[1])
+    yyyy, mm, dd, hh = string_to_yyyymmddhh(args.datetime)
     startDate = datetime.datetime(yyyy, mm, dd, hh)
 
     if args.until_datetime != None:
-        tmp = args.until_datetime.split('-')
-        yyyy = int(tmp[0])
-        mm = int(tmp[1])
-        ddhh = tmp[2]
-        dd = int(ddhh.split('_')[0])
-        hh = int(ddhh.split('_')[1])
+        yyyy, mm, dd, hh = string_to_yyyymmddhh(args.until_datetime)
         endDate = datetime.datetime(yyyy, mm, dd, hh)
     else:
         endDate = startDate

--- a/era5_to_int.py
+++ b/era5_to_int.py
@@ -27,6 +27,13 @@ def intdate_to_string(utc_int):
     return '{:04d}-{:02d}-{:02d}_{:02d}:00:00'.format(year, month, day, hour)
 
 
+def datetime_to_string(dt):
+    """ Converts a Python datetime instance into a string of the form
+    'yyyy-mm-dd_hh'.
+    """
+    return '{:04d}-{:02d}-{:02d}_{:02d}'.format(dt.year, dt.month, dt.day, dt.hour)
+
+
 def begin_6hourly(yyyy, mm, dd, hh):
     """ Returns a date-time string of the form yyyymmddhh for the year, month,
     day, and hour with the hours rounded down the the beginning of a six-hour
@@ -202,18 +209,68 @@ def add_trailing_slash(str):
         return str + '/'
 
 
+def handle_datetime_args(args):
+    """ Returns starting and ending datetime objects along with an interval
+    timedelta object given an argparse namespace with members 'datetime',
+    'until_datetime', and 'interval_hours'. If 'until_datetime' is None,
+    the returned ending datetime is the same as the starting datetime.
+    If 'interval_hours' is 0, it defaults to a interval of six hours.
+    """
+
+    tmp = args.datetime.split('-')
+    yyyy = int(tmp[0])
+    mm = int(tmp[1])
+    ddhh = tmp[2]
+    dd = int(ddhh.split('_')[0])
+    hh = int(ddhh.split('_')[1])
+    startDate = datetime.datetime(yyyy, mm, dd, hh)
+
+    if args.until_datetime != None:
+        tmp = args.until_datetime.split('-')
+        yyyy = int(tmp[0])
+        mm = int(tmp[1])
+        ddhh = tmp[2]
+        dd = int(ddhh.split('_')[0])
+        hh = int(ddhh.split('_')[1])
+        endDate = datetime.datetime(yyyy, mm, dd, hh)
+    else:
+        endDate = startDate
+
+    if endDate < startDate:
+        raise ValueError('until_datetime precedes datetime')
+
+    if args.interval_hours > 0:
+        intvH = datetime.timedelta(hours=args.interval_hours)
+    else:
+        raise ValueError('interval_hours is not a positive integer')
+
+    return startDate, endDate, intvH
+
+
 if __name__ == '__main__':
     from netCDF4 import Dataset
     import numpy as np
     import WPSUtils
     import argparse
+    import datetime
+    import sys
 
     parser = argparse.ArgumentParser()
     parser.add_argument('datetime', help='the date-time to convert in YYYY-MM-DD_HH format')
+    parser.add_argument('until_datetime', nargs='?', default=None, help='the date-time in YYYY-MM-DD_HH format until which records are converted (Default: datetime)')
+    parser.add_argument('interval_hours', type=int, nargs='?', default=6, help='the interval in hours between records to be converted (Default: %(default)s)')
     parser.add_argument('-p', '--path', help='the local path to search for ERA5 netCDF files')
     args = parser.parse_args()
 
-    initdate = args.datetime
+    try:
+        startDate, endDate, intvH = handle_datetime_args(args)
+    except ValueError as e:
+        print('Error in argument list: ' + e.args[0])
+        sys.exit(1)
+
+    print('datetime = ', startDate)
+    print('until_datetime = ', endDate)
+    print('interval_hours = ', intvH)
 
     # Set up the two map projections used in the ERA5 fields to be converted
     Gaussian = MapProjection(WPSUtils.Projections.GAUSS,
@@ -241,40 +298,47 @@ if __name__ == '__main__':
     int_vars.append(MetVar('PSFC', 'SP', 'e5.oper.an.ml.128_134_sp.regn320sc.{}_{}.nc', begin_6hourly, end_6hourly, Gaussian))
     int_vars.append(MetVar('SOILGEO', 'Z', 'e5.oper.invariant.128_129_z.regn320sc.2016010100_2016010100.nc', begin_monthly, end_monthly, Gaussian, isInvariant=True))
 
-    intfile = WPSUtils.IntermediateFile('ERA5', initdate)
-
     if args.path != None:
         paths = [ add_trailing_slash(p) for p in args.path.split(',') ]
     else:
         paths = None
 
-    for v in int_vars:
-        e5filename = find_era5_file(v, initdate, localpaths=paths)
-        idx = find_time_index(e5filename, initdate)
-        if idx == -1:
-            idx = 0
-        proj = v.mapProj
+    currDate = startDate
+    while currDate <= endDate:
+        initdate = datetime_to_string(currDate)
+        print('Processing time record ' + initdate)
 
-        print(e5filename)
-        with Dataset(e5filename) as f:
-            hdate = intdate_to_string(f.variables['utc_date'][idx])
-            print('Converting ' + v.WPSname + ' at ' + hdate)
-            map_source = 'ERA5 reanalysis grid          '
-            units = f.variables[v.ERA5name].units
-            desc = f.variables[v.ERA5name].long_name
-            field_arr = f.variables[v.ERA5name][idx,:]
+        intfile = WPSUtils.IntermediateFile('ERA5', initdate)
 
-            if field_arr.ndim == 2:
-                slab = field_arr
-                xlvl = 200100.0
-                if v.WPSname == 'SOILGEO':
-                    xlvl = 1.0
-                write_slab(intfile, slab, xlvl, proj, v.WPSname, hdate, units,
-                    map_source, desc)
-            else:
-                for k in range(f.dimensions['level'].size):
-                    slab = field_arr[k,:,:]
-                    write_slab(intfile, slab, float(f.variables['level'][k]), proj,
-                        v.WPSname, hdate, units, map_source, desc)
+        for v in int_vars:
+            e5filename = find_era5_file(v, initdate, localpaths=paths)
+            idx = find_time_index(e5filename, initdate)
+            if idx == -1:
+                idx = 0
+            proj = v.mapProj
 
-    intfile.close()
+            print(e5filename)
+            with Dataset(e5filename) as f:
+                hdate = intdate_to_string(f.variables['utc_date'][idx])
+                print('Converting ' + v.WPSname + ' at ' + hdate)
+                map_source = 'ERA5 reanalysis grid          '
+                units = f.variables[v.ERA5name].units
+                desc = f.variables[v.ERA5name].long_name
+                field_arr = f.variables[v.ERA5name][idx,:]
+
+                if field_arr.ndim == 2:
+                    slab = field_arr
+                    xlvl = 200100.0
+                    if v.WPSname == 'SOILGEO':
+                        xlvl = 1.0
+                    write_slab(intfile, slab, xlvl, proj, v.WPSname, hdate, units,
+                        map_source, desc)
+                else:
+                    for k in range(f.dimensions['level'].size):
+                        slab = field_arr[k,:,:]
+                        write_slab(intfile, slab, float(f.variables['level'][k]), proj,
+                            v.WPSname, hdate, units, map_source, desc)
+
+        intfile.close()
+
+        currDate += intvH


### PR DESCRIPTION
This PR enables the conversion of a range of date-times using optional positional arguments.

Conversion of a range of date-times from ERA5 data is now possible through two
new optional positional arguments to the `era5_to_int.py` script:
    
  - `until_datetime` : the date-time until which ERA5 data should be converted
                     (default value: `datetime`, i.e., the initial date-time to
                      convert)
  - `interval_hours` : the interval between ERA5 time records to convert
                     (default value: 6 hours)
    
Converting a single time record of ERA5 netCDF data is specified as before
using a single positional argument, e.g.,
```
  era5_to_int.py 2024-05-01_00
``` 
while converting a range of time records is specified with the initial date-time
and the final date-time, e.g.,
```
  era5_to_int.py 2024-05-01_00 2024-05-31_18
```
Additionally, the interval (in hours) between time records to be converted may 
be specified with a third argument, e.g.,
```
  era5_to_int.py 2024-05-01_00 2024-05-31_21 3
```
.   
