### PR TITLE
Add ability to processing pressure-level (isobaric) ERA5 netCDF files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # era5_to_int
 
-A simple Python script for converting ERA5 model-level netCDF files to the WPS
-intermediate format
+A simple Python script for converting ERA5 netCDF files to the WPS intermediate
+format
 
 ## Overview
 
-The `era5_to_int.py` script converts ERA5 model-level netCDF files to the WRF
-Pre-processing System (WPS) intermediate file format, permitting the use of
-these data with either the Weather Research and Forecasting (WRF) model or the
-Model for Prediction Across Scales - Atmosphere (MPAS-A).
+The `era5_to_int.py` script converts ERA5 model- or pressure-level netCDF files
+to the WRF Pre-processing System (WPS) intermediate file format, permitting the
+use of these data with either the Weather Research and Forecasting (WRF) model
+or the Model for Prediction Across Scales - Atmosphere (MPAS-A).
 
 The only required command-line argument is the date-time, in YYYY-MM-DD_HH
-format, of ERA5 model-level files to convert. For example:
+format, of ERA5 files to convert. For example:
 ```
 era5_to_int.py 2024-05-01_00
 ```
@@ -19,14 +19,10 @@ era5_to_int.py 2024-05-01_00
 Conversion of a range of date-times is possible through the use of additional
 command-line arguments as described in the Usage section.
 
-The following fields from the ds633 datasets are handled by the script:
+The following surface fields from the d633 datasets are handled by the script:
 
 | Field   | Dataset | Horiz. grid | Num. levels |
 |---------|---------|-------------|-------------|
-| Q       | [d633006](https://rda.ucar.edu/datasets/d633006/) | ~0.281-deg Gaussian | 137 |
-| T       | [d633006](https://rda.ucar.edu/datasets/d633006/) | ~0.281-deg Gaussian | 137 |
-| U       | [d633006](https://rda.ucar.edu/datasets/d633006/) | ~0.281-deg Gaussian | 137 |
-| V       | [d633006](https://rda.ucar.edu/datasets/d633006/) | ~0.281-deg Gaussian | 137 |
 | SOILGEO | [d633000](https://rda.ucar.edu/datasets/d633000/) | ~0.281-deg Gaussian | 1 |
 | SP      | [d633006](https://rda.ucar.edu/datasets/d633006/) | ~0.281-deg Gaussian | 1 |
 | MSL     | [d633000](https://rda.ucar.edu/datasets/d633000/) | 0.25-deg Lat-Lon | 1 |
@@ -48,6 +44,28 @@ The following fields from the ds633 datasets are handled by the script:
 | STL3    | [d633000](https://rda.ucar.edu/datasets/d633000/) | 0.25-deg Lat-Lon | 1 |
 | STL4    | [d633000](https://rda.ucar.edu/datasets/d633000/) | 0.25-deg Lat-Lon | 1 |
 | CI      | [d633000](https://rda.ucar.edu/datasets/d633000/) | 0.25-deg Lat-Lon | 1 |
+
+When model-level ERA5 files are being processed (the default), the following
+atmospheric fields are handled:
+
+| Field   | Dataset | Horiz. grid | Num. levels |
+|---------|---------|-------------|-------------|
+| Q       | [d633006](https://rda.ucar.edu/datasets/d633006/) | ~0.281-deg Gaussian | 137 |
+| T       | [d633006](https://rda.ucar.edu/datasets/d633006/) | ~0.281-deg Gaussian | 137 |
+| U       | [d633006](https://rda.ucar.edu/datasets/d633006/) | ~0.281-deg Gaussian | 137 |
+| V       | [d633006](https://rda.ucar.edu/datasets/d633006/) | ~0.281-deg Gaussian | 137 |
+
+Alternatively, if the processing of pressure-level (isobaric) ERA5 files is
+selected with the `-i` / `--isobaric` command-line option, the following
+atmospheric fields are instead handled:
+
+| Field   | Dataset | Horiz. grid | Num. levels |
+|---------|---------|-------------|-------------|
+| Z       | [d633000](https://rda.ucar.edu/datasets/d633000/) | 0.25-deg Lat-Lon | 37 |
+| Q       | [d633000](https://rda.ucar.edu/datasets/d633000/) | 0.25-deg Lat-Lon | 37 |
+| T       | [d633000](https://rda.ucar.edu/datasets/d633000/) | 0.25-deg Lat-Lon | 37 |
+| U       | [d633000](https://rda.ucar.edu/datasets/d633000/) | 0.25-deg Lat-Lon | 37 |
+| V       | [d633000](https://rda.ucar.edu/datasets/d633000/) | 0.25-deg Lat-Lon | 37 |
 
 As fields are converted from netCDF to intermediate format, their names are also
 converted to match WPS and MPAS-A expectations.
@@ -73,7 +91,7 @@ With no optional arguments, the script will search known paths on the NWSC Glade
 filesystem for ERA5 model-level netCDF files. If the `-p`/`--path` option is
 provided with a local path, the script will instead search that local path for
 ERA5 files that have been downloaded from the NSF NCAR Research Data Archive
-(RDA) ds633 datasets. For example:
+(RDA) d633 datasets. For example:
 ```
 era5_to_int.py --path /some/data/directory/era5 2024-05-01_00
 ```
@@ -95,16 +113,18 @@ era5_to_int.py 2024-05-01_00 2024-05-31_21 3
 Usage is provided by running the `era5_to_int.py` script with the `-h`/`--help`
 argument, which prints the following:
 ```
-usage: era5_to_int.py [-h] [-p PATH] datetime [until_datetime] [interval_hours]
+usage: era5_to_int.py [-h] [-p PATH] [-i] datetime [until_datetime] [interval_hours]
 
 positional arguments:
   datetime              the date-time to convert in YYYY-MM-DD_HH format
-  until_datetime        the date-time in YYYY-MM-DD_HH format until which records are converted (Default: datetime)
+  until_datetime        the date-time in YYYY-MM-DD_HH format until which records are converted (Default:
+                        datetime)
   interval_hours        the interval in hours between records to be converted (Default: 6)
 
 options:
   -h, --help            show this help message and exit
   -p PATH, --path PATH  the local path to search for ERA5 netCDF files
+  -i, --isobaric        use ERA5 pressure-level data rather than model-level data
 ```
 
 ## Supplementary files
@@ -112,4 +132,4 @@ options:
 Included in this repository is a list of ECMWF vertical level coefficients in
 the `ecmwf_coeffs` file. The `ecmwf_coeffs` file may be used with the WPS
 `calc_ecmwf_p.exe` utility program to generate an intermediate file with 3-d
-pressure, geopotential height, and R.H. fields.
+pressure, geopotential height, and R.H. fields from ERA5 model-level data.


### PR DESCRIPTION
This PR adds the ability to process pressure-level (isobaric) ERA5 netCDF files through a new command-line option, `-i`/`--isobaric`. The default behavior without this option is to process model-level ERA5 files, as was done prior to this PR.

Specific changes include:
 - A new command-line option `-i`/`--isobaric` to specify the processing of pressure-level ERA5 files rather than the default model-level ERA files
 - Addition of a search path on the Glade filesystem for pressure-level ERA5 files
 - Modification of the set of atmospheric fields that are processed when using pressure-level file
 - Updates to the `README.md` file