### PR TITLE
Add geopotential height diagnostics for surface and upper-air levels

### DIFF
--- a/era5_to_int.py
+++ b/era5_to_int.py
@@ -74,6 +74,35 @@ class RH2mDiags:
             self.td = None
 
 
+class GeopotentialHeightDiags:
+    """ Implements the computation of SOILHGT and GHT (geopotential height at
+    the surface and at upper-air levels, respectively) from ERA5 Z
+    (geopotential), whose WPS name is either GEOPT at upper-air levels or
+    SOILGEO at the surface.
+    """
+
+    def consider(self, field, xlvl, proj, hdate, slab, intfile):
+        """ Considers whether the given field represents geopotential, and if
+        so, computes geopotential height, writing the result to the output
+        intermediate file.
+        """
+
+        if field == 'GEOPT':
+            print('Computing GHT at ', xlvl)
+
+            write_slab(intfile, slab / 9.81, xlvl, proj, 'GHT', hdate, 'm',
+                'ERA5 reanalysis grid', 'Geopotential height')
+
+        elif field == 'SOILGEO':
+            print('Computing SOILHGT')
+
+            write_slab(intfile, slab / 9.81, 200100.0, proj, 'SOILHGT', hdate, 'm',
+                'ERA5 reanalysis grid', 'Geopotential height')
+
+        else:
+            return
+
+
 def days_in_month(year, month):
     """ Returns the number of days in a month, depending on the year.
     A Gregorian calendar is assumed for the purposes of determining leap
@@ -364,6 +393,7 @@ if __name__ == '__main__':
     diagnostics = []
     diagnostics.append(SnowDiags())
     diagnostics.append(RH2mDiags())
+    diagnostics.append(GeopotentialHeightDiags())
 
     int_vars = []
     if args.isobaric:


### PR DESCRIPTION
This PR adds diagnostic computations of geopotential height for surface and upper-air levels.

The `GEOPT` (geopotential) field for upper-air levels is now used to compute `GHT`
(geopotential height), and the `SOILGEO` (surface geopotential) field is used to
compute `SOILHGT` (surface geopotential height).