### PR TITLE
Update paths to ERA5 netCDF files on the NWSC Glade filesystem

### DIFF
--- a/era5_to_int.py
+++ b/era5_to_int.py
@@ -246,11 +246,14 @@ def find_era5_file(var, validtime, localpaths=None):
     import os.path
 
     glade_paths = [
+        # New Glade paths as of March 2025
         '/glade/campaign/collections/rda/data/d633006/e5.oper.an.ml/',
         '/glade/campaign/collections/rda/data/d633000/e5.oper.an.pl/',
         '/glade/campaign/collections/rda/data/d633000/e5.oper.an.sfc/',
         '/glade/campaign/collections/rda/data/d633000/e5.oper.invariant/197901/',
         '/glade/campaign/collections/rda/data/d633006/e5.oper.invariant/',
+
+        # Old Glade paths prior to March 2025
         '/glade/campaign/collections/rda/data/ds633.6/e5.oper.an.ml/',
         '/glade/campaign/collections/rda/data/ds633.0/e5.oper.an.pl/',
         '/glade/campaign/collections/rda/data/ds633.0/e5.oper.an.sfc/',

--- a/era5_to_int.py
+++ b/era5_to_int.py
@@ -246,6 +246,11 @@ def find_era5_file(var, validtime, localpaths=None):
     import os.path
 
     glade_paths = [
+        '/glade/campaign/collections/rda/data/d633006/e5.oper.an.ml/',
+        '/glade/campaign/collections/rda/data/d633000/e5.oper.an.pl/',
+        '/glade/campaign/collections/rda/data/d633000/e5.oper.an.sfc/',
+        '/glade/campaign/collections/rda/data/d633000/e5.oper.invariant/197901/',
+        '/glade/campaign/collections/rda/data/d633006/e5.oper.invariant/',
         '/glade/campaign/collections/rda/data/ds633.6/e5.oper.an.ml/',
         '/glade/campaign/collections/rda/data/ds633.0/e5.oper.an.pl/',
         '/glade/campaign/collections/rda/data/ds633.0/e5.oper.an.sfc/',


### PR DESCRIPTION
This PR updates the paths to search for ERA5 netCDF files on the NWSC Glade filesystem.

The paths of ERA5 netCDF files on the NWSC Glade filesystem have changed, and this PR updates the `glade_paths` list in the `find_era5_file` function to contain these new paths.

The old Glade paths have been left in place just in case the ERA5 netCDF files revert to their old locations. In future, these old paths could be removed, though.

Note that the changes in this PR do not affect any searching of ERA5 files in local paths specified with the `-p`/`--path` command-line option.