### PR TITLE
Use consistent fill value of -1.0e30 for missing values in intermediate output

### DIFF
--- a/era5_to_int.py
+++ b/era5_to_int.py
@@ -401,12 +401,13 @@ def write_slab( intfile, slab, xlvl, proj, WPSname, hdate, units, map_source, de
     through a previous call to the WPSUtils.intermediate.write_met_init
     routine.
     """
+    missing_value = -1.0e30
     stat = intfile.write_next_met_field(
         5, slab.shape[1], slab.shape[0], proj.projType, 0.0, xlvl,
         proj.startLat, proj.startLon, proj.startI, proj.startJ,
         proj.deltaLat, proj.deltaLon, proj.dx, proj.dy, proj.xlonc,
         proj.truelat1, proj.truelat2, 6371229.0, 0, WPSname,
-        hdate, units, map_source, desc, slab)
+        hdate, units, map_source, desc, slab.filled(missing_value))
 
 
 def add_trailing_slash(str):


### PR DESCRIPTION
This PR modifies the `write_slab` function so that a fill value of -1.0e30 is used for missing values in intermediate output files.

The netCDF4 module returns NumPy masked arrays when reading ERA5 netCDF files, and the fill value provided in the ERA5 files may not match the missing value of -1.0e30 that is expected by the WPS and MPAS-A. For example, the ERA5 `SEAICE` (`CI`) field from ds633.0 uses a fill value of 9.999e20. This discrepancy in expected and actual fill value can lead to problems when interpolated masked fields like `SEAICE`.

So that the intermediate output files will consistently use -1.0e30 for filling missing values, the `write_slab` function now converts its `slab` array argument to an ndarray with a specified fill value of -1.0e30.