### PR TITLE
Introduce user-specified output path for intermediate files on command line via -o, --output_path

### DIFF
--- a/era5_to_int.py
+++ b/era5_to_int.py
@@ -456,6 +456,7 @@ if __name__ == '__main__':
     import argparse
     import datetime
     import sys
+    import os
 
     parser = argparse.ArgumentParser()
     parser.add_argument('datetime', help='the date-time to convert in YYYY-MM-DD_HH format')
@@ -464,6 +465,7 @@ if __name__ == '__main__':
     parser.add_argument('-p', '--path', help='the local path to search for ERA5 netCDF files')
     parser.add_argument('-i', '--isobaric', action='store_true', help='use ERA5 pressure-level data rather than model-level data')
     parser.add_argument('-v', '--variables', help='a comma-separated list, without spaces, of WPS variable names to process')
+    parser.add_argument('-o', '--output_path', help='directory where WPS intermediate files will be written (default: current directory)', default='.')
     args = parser.parse_args()
 
     try:
@@ -475,6 +477,10 @@ if __name__ == '__main__':
     print('datetime = ', startDate)
     print('until_datetime = ', endDate)
     print('interval_hours = ', intvH)
+
+    # Ensure output directory exists
+    outdir = add_trailing_slash(args.output_path)
+    os.makedirs(outdir, exist_ok=True)
 
     # Set up the two map projections used in the ERA5 fields to be converted
     Gaussian = MapProjection(WPSUtils.Projections.GAUSS,
@@ -563,7 +569,9 @@ if __name__ == '__main__':
         initdate = datetime_to_string(currDate)
         print('Processing time record ' + initdate)
 
-        intfile = WPSUtils.IntermediateFile('ERA5', initdate)
+        # Create intermediate file in user-specified output directory
+        outfile_prefix = os.path.join(outdir, 'ERA5')
+        intfile = WPSUtils.IntermediateFile(outfile_prefix, initdate)
 
         for v in int_vars:
 


### PR DESCRIPTION
Hello NCAR, 

When using Glade, some directories have Python access and allow users to install python packages (necessary for this script) while others do not. As such, I find it useful to be able to dump the intermediate files in a user-specified directory if this script can not be used in that directory. 

Here I introduce a new command line argument (``-o``, ``--output_path``) that lets a user set the file path where they'd like the intermediate files to be saved to. 

Example:

``era5_to_int.py -i 2010-06-16_12 2010-06-18_12 -o /glade/derecho/scratch/kgillett/atsc_405_f2025/era5wrf/wpsv4.3.1/"